### PR TITLE
Update Button on different Page

### DIFF
--- a/front/src/pages/BuildPage.js
+++ b/front/src/pages/BuildPage.js
@@ -242,7 +242,7 @@ function BuildPage() {
             >
               Build
             </button>
-
+<!-- update Button--->
             <button
               onClick={() =>
                 handleUpdate(


### PR DESCRIPTION
Adding an update button on the page where the build list is given would make it better. The form would be populated with data already present and then update values. The update button on this page doesn't tell me which data I want to update.